### PR TITLE
bug/18731_help_link_has_the_wrong_url

### DIFF
--- a/lib/open_project/help_link/engine.rb
+++ b/lib/open_project/help_link/engine.rb
@@ -26,7 +26,7 @@ module OpenProject::HelpLink
     engine_name :openproject_help_link
 
     def self.settings
-      { :default => {"help_link_target" => "https://www.openproject.org/projects/support"},
+      { :default => {"help_link_target" => "https://www.openproject.org/help"},
         :partial => "settings/openproject_help_link_settings.html.erb" }
     end
 

--- a/lib/open_project/help_link/engine.rb
+++ b/lib/open_project/help_link/engine.rb
@@ -26,8 +26,12 @@ module OpenProject::HelpLink
     engine_name :openproject_help_link
 
     def self.settings
-      { :default => {"help_link_target" => "https://www.openproject.org/help"},
-        :partial => "settings/openproject_help_link_settings.html.erb" }
+      {
+        default: {
+          'help_link_target' => 'https://www.openproject.org/help'
+        },
+        partial: 'settings/openproject_help_link_settings.html.erb'
+      }
     end
 
     include OpenProject::Plugins::ActsAsOpEngine


### PR DESCRIPTION
help url should default to https://www.openproject.org/help

https://community.openproject.org/work_packages/18731
